### PR TITLE
Remove global variables and fix functions

### DIFF
--- a/consensus/eccpow/algorithm_test.go
+++ b/consensus/eccpow/algorithm_test.go
@@ -10,12 +10,11 @@ import (
 
 func TestRandomSeed(t *testing.T) {
 	prev_hash := hexutil.MustDecode("0xc9149cc0386e689d789a1c2f3d5d169a61a6218ed30e74414dc736e442ef3d1f")
-
-	SetDifficultyUsingLevel(2)
-
+	parameter := SetDifficultyUsingLevel(0)
 	GenerateSeed(prev_hash)
-	a := GenerateH()
-	b := GenerateH()
+
+	a := GenerateH(parameter)
+	b := GenerateH(parameter)
 
 	if !reflect.DeepEqual(a, b) {
 		t.Error("Wrong matrix")

--- a/consensus/eccpow/sealer.go
+++ b/consensus/eccpow/sealer.go
@@ -90,6 +90,7 @@ func (ecc *ECC) Seal(chain consensus.ChainReader, block *types.Block, results ch
 			ecc.mine(block, id, nonce, abort, locals)
 		}(i, uint64(ecc.rand.Int63()))
 	}
+
 	// Wait until sealing is terminated or a nonce is found
 	go func() {
 		var result *types.Block
@@ -115,6 +116,7 @@ func (ecc *ECC) Seal(chain consensus.ChainReader, block *types.Block, results ch
 		// Wait for all miners to terminate and return the block
 		pend.Wait()
 	}()
+	fmt.Println("Done")
 	return nil
 }
 
@@ -153,6 +155,7 @@ search:
 			attempts = 0
 		}
 		// Compute the PoW value of this nonce
+
 		nonce, digest, matrix := RunLDPC(header.ParentHash.Bytes(), hash)
 		fmt.Print(matrix)
 
@@ -169,9 +172,7 @@ search:
 			logger.Trace("ecc nonce found but discarded", "nonce", nonce)
 		}
 		break search
-
 	}
-
 }
 
 // remote is a standalone goroutine to handle remote mining related stuff.


### PR DESCRIPTION
ldpc decoder에서 변수들이 전역변수로 선언되어 있던게 문제였던 것 같습니다.

go test를 하면 Sealer.go의 Seal 함수에서 go routine을 이용해 `RunLDPC()` 함수를 test하는데, 이 과정에서 ldpc docoder의 critical section이 제대로 지켜지지 않아서 out of index error가 발생했습니다.

그래서 전역변수를 제거하기위해 함수 내부에서 변수를 선언하고 return 하는 방식으로 수정했습니다. 이 과정에서 불필요한 return은 제거하고 주석 추가했습니다.

go test `SetDifficultyUsingLevel(level)` 함수에서 level을 0 (최하)로 했을 때 정상적으로 동작 하고 pass하는 것 확인 했습니다.

그 이상의 난이도는 시간이 오래걸려서 확인하지 못했습니다.

![test-result](https://user-images.githubusercontent.com/25428581/63794679-6f5c0380-c93d-11e9-9e70-11043d24dc12.png)

ldpc decoder 수정 내용은
https://github.com/HyoungsungKim/ECC-PoW-project/tree/master/ldpc 에도 업데이트 됐습니다.